### PR TITLE
Fixed standard separators bug

### DIFF
--- a/Source/BaseTableDataDisplayManager.swift
+++ b/Source/BaseTableDataDisplayManager.swift
@@ -42,7 +42,6 @@ public class BaseTableDataDisplayManager: NSObject, TableDataDisplayManager {
         self.tableView = tableView
         self.tableView?.delegate = self
         self.tableView?.dataSource = self
-        self.tableView?.separatorStyle = .none
     }
 }
 


### PR DESCRIPTION
There was a bug - separators wasn't appear because BaseTableDataDisplayManager sets `separatorStyle` as none.
I've removed `separatorStyle` setting in this pull request. You can set separator style in your view controller or .storyboard/.xib.